### PR TITLE
Delegate moveit_full to moveit metapackage.

### DIFF
--- a/moveit_full/package.xml
+++ b/moveit_full/package.xml
@@ -14,11 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>moveit_ros</run_depend>
-  <run_depend>moveit_planners</run_depend>
-  <run_depend>moveit_setup_assistant</run_depend>
-  <run_depend>moveit_commander</run_depend>
-  <run_depend>moveit_plugins</run_depend>
+  <run_depend>moveit</run_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
**Background of this PR**
Pointed out at https://github.com/ros-planning/moveit.ros.org/pull/113#issuecomment-270622120 by @v4hn that we actually haven't decided to remove `moveit_full` for Indigo. Looks like he's correct. I'm sorry that I might have confused myself somehow with [decisions for Jade and Kinetic](https://github.com/ros-planning/moveit_ros/issues/692#issuecomment-238719902).

For the backaward compatibility, I'll re-add moveit_metapackage [that I removed](https://github.com/ros/rosdistro/pull/13442/files#diff-4bbb8e35ff5dc5e7f2d7b4d00374533fL6367) before releasing `moveit` into Indigo. 

The change made in https://github.com/ros-planning/moveit.ros.org/pull/113 to switch installation step from `ros-indigo-moveit-full` to `ros-indigo-moveit` can be kept as it is IMO.

**What does this PR can improve**

Since we now have `moveit` metapackage, moveit_full *can* depend on it and avoid maintaining yet another metapackage with list of sub packages. 
This doesn't work, however, on distros prior to Indigo where `moveit` is not available. So we might want to split branches?

Another option is, we don't need the change suggested in this PR, keep `master` branch. I'm ok with that too.

